### PR TITLE
Adds two changes to audience and unit fields (v1.1)

### DIFF
--- a/config/optional/field.field.node.ucb_article.field_syndication_audience.yml
+++ b/config/optional/field.field.node.ucb_article.field_syndication_audience.yml
@@ -23,6 +23,6 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: true
+    auto_create: false
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/optional/field.field.node.ucb_article.field_syndication_unit.yml
+++ b/config/optional/field.field.node.ucb_article.field_syndication_unit.yml
@@ -23,6 +23,6 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: true
+    auto_create: false
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/optional/field.storage.node.field_syndication_audience.yml
+++ b/config/optional/field.storage.node.field_syndication_audience.yml
@@ -12,7 +12,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/optional/field.storage.node.field_syndication_unit.yml
+++ b/config/optional/field.storage.node.field_syndication_unit.yml
@@ -12,7 +12,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/src/ArticleSyndication.php
+++ b/src/ArticleSyndication.php
@@ -40,7 +40,7 @@ class ArticleSyndication {
     $hidden = $articleContentTypeConfig->get('hidden');
 
     $content['field_syndication_audience'] = [
-      'type' => 'entity_reference_autocomplete',
+      'type' => 'entity_reference_autocomplete_tags',
       'weight' => 98,
       'region' => 'content',
       'settings' => [
@@ -52,7 +52,7 @@ class ArticleSyndication {
       'third_party_settings' => [],
     ];
     $content['field_syndication_unit'] = [
-      'type' => 'entity_reference_autocomplete',
+      'type' => 'entity_reference_autocomplete_tags',
       'weight' => 99,
       'region' => 'content',
       'settings' => [

--- a/ucb_article_syndication.info.yml
+++ b/ucb_article_syndication.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Article Syndication
 description: Extends the article content type to add the taxonomies needed for article syndication.
 core_version_requirement: ^10 || ^11
 type: module
-version: '1.0.1'
+version: '1.1'
 package: CU Boulder
 dependencies:
   - cu_boulder_content_types


### PR DESCRIPTION
This update:

- Sets audience and unit fields to allow unlimited items.
- Changes audience and unit form display to Autocomplete (Tags style)

[change] Resolves CuBoulder/ucb_article_syndication#4

Technical information: This update does _not_ contain an update hook. Corresponding changes will need to be made manually on the CU Boulder Today site.