### PR TITLE
Adds Article Syndication "read more" article list (v1.2)

### DIFF
--- a/src/ArticleSyndication.php
+++ b/src/ArticleSyndication.php
@@ -139,10 +139,13 @@ class ArticleSyndication {
    * category, audience, and unit term ids to be passed in as URL parameters.
    * Its main use case is to be used as the "read more" page for the Campus
    * News block.
+   *
+   * A new article list will be created only if a node doesn’t already exist at
+   * the same path.
    */
   public function createSyndicationArticleList() {
     if (preg_match('/node\/(\d+)/', $this->aliasManager->getPathByAlias($this::SYNDICATION_PATH))) {
-      $this->logger->warning('A syndication article list wasn’t created because a node already exists at that path.');
+      $this->logger->warning('A syndication article list wasn’t created because a node already exists at the path ' . $this::SYNDICATION_PATH . '.');
     }
     else {
       $node = Node::create([

--- a/src/ArticleSyndication.php
+++ b/src/ArticleSyndication.php
@@ -133,7 +133,12 @@ class ArticleSyndication {
   }
 
   /**
-   * Creates the `/syndication` article list.
+   * Creates the syndication article list.
+   *
+   * The syndication article list is a special article list which allows
+   * category, audience, and unit term ids to be passed in as URL parameters.
+   * Its main use case is to be used as the "read more" page for the Campus
+   * News block.
    */
   public function createSyndicationArticleList() {
     if (preg_match('/node\/(\d+)/', $this->aliasManager->getPathByAlias($this::SYNDICATION_PATH))) {

--- a/src/ArticleSyndication.php
+++ b/src/ArticleSyndication.php
@@ -144,14 +144,18 @@ class ArticleSyndication {
    * the same path.
    */
   public function createSyndicationArticleList() {
-    if (preg_match('/node\/(\d+)/', $this->aliasManager->getPathByAlias($this::SYNDICATION_PATH))) {
-      $this->logger->warning('A syndication article list wasn’t created because a node already exists at the path ' . $this::SYNDICATION_PATH . '.');
+    $pathAlias = $this::SYNDICATION_PATH;
+    if (preg_match('/node\/(\d+)/', $this->aliasManager->getPathByAlias($pathAlias))) {
+      $this->logger->warning("A syndication article list wasn’t created because a node already exists at the path alias $pathAlias.");
     }
     else {
       $node = Node::create([
         'type' => 'ucb_article_list',
         'title' => 'Article Results',
-        'path' => ['alias' => $this::SYNDICATION_PATH, 'pathauto' => PathautoState::SKIP],
+        'path' => [
+          'alias' => $pathAlias,
+          'pathauto' => PathautoState::SKIP,
+        ],
         'body' => '',
       ]);
       $node->enforceIsNew()->save();

--- a/src/ArticleSyndication.php
+++ b/src/ArticleSyndication.php
@@ -14,6 +14,11 @@ use Psr\Log\LoggerInterface;
 class ArticleSyndication {
 
   /**
+   * The path alias at which the syndication article list should reside.
+   */
+  const SYNDICATION_PATH = '/syndicate';
+
+  /**
    * The config factory.
    *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
@@ -131,14 +136,14 @@ class ArticleSyndication {
    * Creates the `/syndication` article list.
    */
   public function createSyndicationArticleList() {
-    if (preg_match('/node\/(\d+)/', $this->aliasManager->getPathByAlias('/syndication'))) {
+    if (preg_match('/node\/(\d+)/', $this->aliasManager->getPathByAlias($this::SYNDICATION_PATH))) {
       $this->logger->warning('A syndication article list wasn’t created because a node already exists at that path.');
     }
     else {
       $node = Node::create([
         'type' => 'ucb_article_list',
         'title' => 'Article Results',
-        'path' => ['alias' => '/syndication', 'pathauto' => PathautoState::SKIP],
+        'path' => ['alias' => $this::SYNDICATION_PATH, 'pathauto' => PathautoState::SKIP],
         'body' => '',
       ]);
       $node->enforceIsNew()->save();

--- a/ucb_article_syndication.info.yml
+++ b/ucb_article_syndication.info.yml
@@ -2,7 +2,7 @@ name: CU Boulder Article Syndication
 description: Extends the article content type to add the taxonomies needed for article syndication.
 core_version_requirement: ^10 || ^11
 type: module
-version: '1.1'
+version: '1.2'
 package: CU Boulder
 dependencies:
   - cu_boulder_content_types

--- a/ucb_article_syndication.info.yml
+++ b/ucb_article_syndication.info.yml
@@ -2,10 +2,12 @@ name: CU Boulder Article Syndication
 description: Extends the article content type to add the taxonomies needed for article syndication.
 core_version_requirement: ^10 || ^11
 type: module
-version: '1.0.1'
+version: '1.1'
 package: CU Boulder
 dependencies:
   - cu_boulder_content_types
   - field
   - node
+  - path_alias
+  - pathauto
   - taxonomy

--- a/ucb_article_syndication.install
+++ b/ucb_article_syndication.install
@@ -13,4 +13,5 @@
 function ucb_article_syndication_install() {
   $articleSyndication = \Drupal::service('ucb_article_syndication');
   $articleSyndication->showSyndicationFields();
+  $articleSyndication->createSyndicationArticleList();
 }

--- a/ucb_article_syndication.services.yml
+++ b/ucb_article_syndication.services.yml
@@ -1,5 +1,10 @@
 services:
+  logger.channel.ucb_article_syndication:
+    parent: logger.channel_base
+    arguments: ['ucb_article_syndication']
   ucb_article_syndication:
     class: 'Drupal\ucb_article_syndication\ArticleSyndication'
     arguments:
       - '@config.factory'
+      - '@path_alias.manager'
+      - '@logger.channel.ucb_article_syndication'


### PR DESCRIPTION
This update adds the Article Syndication "read more" article list, for use with the Campus News block. The article list is automatically created on sites using the CU Boulder Article Syndication module (if it doesn't already exist) and aliased to `/syndicate`. It allows URL parameters to specify category, audience, and unit filters.

[new] Resolves CuBoulder/ucb_article_syndication#3

Sister PR in: [tiamat-theme](https://github.com/CuBoulder/tiamat-theme/pull/1542)